### PR TITLE
Upgrade to netstandard2.0

### DIFF
--- a/Magneto.Version.props
+++ b/Magneto.Version.props
@@ -2,6 +2,6 @@
 <Project>
 	<PropertyGroup>
 		<VersionPrefix>1.0.0</VersionPrefix>
-		<VersionSuffix>beta-3</VersionSuffix>
+		<VersionSuffix>beta-4</VersionSuffix>
 	</PropertyGroup>
 </Project>

--- a/samples/Samples.Tests/Samples.Tests.csproj
+++ b/samples/Samples.Tests/Samples.Tests.csproj
@@ -2,12 +2,13 @@
 	<Import Project="..\..\Magneto.Common.props" />
 
 	<PropertyGroup>
-		<TargetFramework>netcoreapp1.1</TargetFramework>
+		<TargetFramework>netcoreapp2.0</TargetFramework>
+		<NoWarn>$(NoWarn);NU1603</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="4.19.2" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
 		<PackageReference Include="NSubstitute" Version="2.0.2" />
 		<PackageReference Include="Serilog" Version="2.4.0" />
 		<PackageReference Include="Specify" Version="2.0.0" />
@@ -17,8 +18,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <ProjectReference Include="..\..\src\Magneto\Magneto.csproj" />
-	  <ProjectReference Include="..\Samples\Samples.csproj" />
+		<ProjectReference Include="..\..\src\Magneto\Magneto.csproj" />
+		<ProjectReference Include="..\Samples\Samples.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/samples/Samples/Samples.csproj
+++ b/samples/Samples/Samples.csproj
@@ -1,32 +1,28 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 	<Import Project="..\..\Magneto.Common.props" />
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.0</TargetFramework>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Content Remove="wwwroot/albums.json" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="BuildBundlerMinifier" Version="2.4.337" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.4-alpha1-170218" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="1.1.0" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="1.0.0" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Magneto.Microsoft\Magneto.Microsoft.csproj" />
-    <ProjectReference Include="..\..\src\Magneto\Magneto.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<Content Remove="wwwroot/albums.json" />
+	</ItemGroup>
+	
+	<ItemGroup>
+		<PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+		<PackageReference Include="BuildBundlerMinifier" Version="2.4.337" />
+		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+		<PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.4-alpha1-170218" />
+	</ItemGroup>
+	
+	<ItemGroup>
+		<DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />
+	</ItemGroup>
+	
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Magneto.Microsoft\Magneto.Microsoft.csproj" />
+		<ProjectReference Include="..\..\src\Magneto\Magneto.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/Magneto.Microsoft/Magneto.Microsoft.csproj
+++ b/src/Magneto.Microsoft/Magneto.Microsoft.csproj
@@ -2,22 +2,28 @@
 	<Import Project="..\..\Magneto.Common.props" />
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard1.1;netstandard1.3</TargetFrameworks>
-		<DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+		<TargetFrameworks>netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
 		<Description>A library extending Magneto with implementations of ICacheStore backed by implementations from Microsoft.Extensions.Caching.</Description>
 		<PackageTags>query command object queryobject commandobject mediator cqs cqrs operation read write cache caching async mock mocking</PackageTags>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<DebugType>embedded</DebugType>
 		<DocumentationFile>$(MSBuildProjectName).xml</DocumentationFile>
-		<NoWarn>1591</NoWarn>
+		<NoWarn>$(NoWarn);1591</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\Magneto\Magneto.csproj" />
 	</ItemGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1' OR '$(TargetFramework)' == 'netstandard1.3'" >
 		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="1.1.1" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'" >
+		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.0.0" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
 		<PackageReference Include="SourceLink.Create.GitHub" Version="2.1.0" PrivateAssets="All" />
 		<PackageReference Include="SourceLink.Test" Version="2.1.0" PrivateAssets="All" />

--- a/src/Magneto/Magneto.csproj
+++ b/src/Magneto/Magneto.csproj
@@ -3,21 +3,21 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard1.1;netstandard1.3;net45;net46</TargetFrameworks>
-		<DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+		<DisableImplicitFrameworkReferences Condition="'$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'net46'">true</DisableImplicitFrameworkReferences>
 		<Description>A library for implementing the Command Pattern, providing of a set of base classes and an invoker class. Useful for abstracting data access and API calls as either queries (for read operations) or commands (for write operations).</Description>
 		<PackageTags>query command object queryobject commandobject mediator cqs cqrs operation read write cache caching async mock mocking</PackageTags>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<DebugType>embedded</DebugType>
 		<DocumentationFile>$(MSBuildProjectName).xml</DocumentationFile>
-		<NoWarn>1591</NoWarn>
+		<NoWarn>$(NoWarn);1591</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1' OR '$(TargetFramework)' == 'netstandard1.3'">
-		<PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
 		<PackageReference Include="System.ComponentModel" Version="4.3.0" />
-		<PackageReference Include="System.Linq" Version="4.3.0" />
-		<PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />
-		<PackageReference Include="System.Threading.Tasks" Version="4.3.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'net46'">
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/test/Magneto.Tests/Magneto.Tests.csproj
+++ b/test/Magneto.Tests/Magneto.Tests.csproj
@@ -3,6 +3,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>netcoreapp1.1</TargetFramework>
+		<NoWarn>$(NoWarn);NU1603</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -11,7 +12,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="4.19.2" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
 		<PackageReference Include="NSubstitute" Version="2.0.2" />
 		<PackageReference Include="Serilog" Version="2.4.0" />
 		<PackageReference Include="Specify" Version="2.0.0" />


### PR DESCRIPTION
This is to fix an issue where the existing version of `Magneto.Microsoft` conflicts and breaks with the newer version of the caching abstractions library, so support for `netstandard1.x` has to be dropped for that. For the main library I've kept the current compatibility, and added `netstandard2.0`.

Double check what I'm doing, I'm a little unsure about `DisableImplicitFrameworkReferences`, I can't get my head around what is best practice today.