### PR TITLE
Make CacheKey member of base CachedQuery class abstract

### DIFF
--- a/samples/Samples/Controllers/UsersController.cs
+++ b/samples/Samples/Controllers/UsersController.cs
@@ -73,6 +73,8 @@ namespace Samples.Controllers
 
 	public class AlbumsByUserId : SyncTransformedCachedQuery<(IFileProvider, ILogger<AlbumsByUserId>), MemoryCacheEntryOptions, Album[], Album[]>
 	{
+		protected override void CacheKey(IKeyConfig keyConfig) => keyConfig.VaryByNothing();
+
 		protected override MemoryCacheEntryOptions CacheEntryOptions((IFileProvider, ILogger<AlbumsByUserId>) context)
 		{
 			var (fileProvider, logger) = context;

--- a/src/Magneto/Core/CachedQuery.cs
+++ b/src/Magneto/Core/CachedQuery.cs
@@ -107,11 +107,10 @@ namespace Magneto.Core
 		internal readonly Store State;
 
 		/// <summary>
-		/// <para>Configures details for constructing a cache key.</para>
-		/// <para>Implementors can choose not to override this method if the cache key doesn't need to vary by anything.</para>
+		/// Configures details for constructing a cache key.
 		/// </summary>
 		/// <param name="keyConfig">The configuration object.</param>
-		protected virtual void CacheKey(IKeyConfig keyConfig) { }
+		protected abstract void CacheKey(IKeyConfig keyConfig);
 
 		/// <summary>
 		/// <para>Returns options pertaining to the cache entry (such as expiration policy).</para>

--- a/src/Magneto/IKeyConfig.cs
+++ b/src/Magneto/IKeyConfig.cs
@@ -1,4 +1,6 @@
 using System;
+using System.ComponentModel;
+using System.Linq;
 
 namespace Magneto
 {
@@ -33,6 +35,7 @@ namespace Magneto
 	/// <summary>
 	/// An extension class for fluent configuration of <see cref="IKeyConfig"/> instances.
 	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static class KeyConfigExtensions
 	{
 		/// <summary>
@@ -59,10 +62,19 @@ namespace Magneto
 		/// keyConfig.VaryBy($"{Foo}_{Baz.Id}")<br/>
 		/// </para>
 		/// </summary>
-		public static IKeyConfig VaryBy(this IKeyConfig keyConfig, params object[] value)
+		public static IKeyConfig VaryBy(this IKeyConfig keyConfig, object firstValue, params object[] additionalValues)
 		{
 			if (keyConfig == null) throw new ArgumentNullException(nameof(keyConfig));
-			keyConfig.VaryBy = value;
+			keyConfig.VaryBy = new[] { firstValue }.Concat(additionalValues);
+			return keyConfig;
+		}
+
+		/// <summary>
+		/// A convenience method to express that the cache key should not vary by anything.
+		/// </summary>
+		public static IKeyConfig VaryByNothing(this IKeyConfig keyConfig)
+		{
+			if (keyConfig == null) throw new ArgumentNullException(nameof(keyConfig));
 			return keyConfig;
 		}
 	}

--- a/test/Magneto.Tests/Core/OperationTests/OperationTests.cs
+++ b/test/Magneto.Tests/Core/OperationTests/OperationTests.cs
@@ -306,18 +306,21 @@ namespace Magneto.Tests.Core.OperationTests
 
 	public class SyncCachedQueryWithoutProperties : SyncCachedQuery<object, object, object>
 	{
+		protected override void CacheKey(IKeyConfig keyConfig) => throw new NotImplementedException();
 		protected override object CacheEntryOptions(object context) => throw new NotImplementedException();
 		protected override object Query(object context) => throw new NotImplementedException();
 	}
 
 	public class AsyncCachedQueryWithoutProperties : AsyncCachedQuery<object, object, object>
 	{
+		protected override void CacheKey(IKeyConfig keyConfig) => throw new NotImplementedException();
 		protected override object CacheEntryOptions(object context) => throw new NotImplementedException();
 		protected override Task<object> Query(object context, CancellationToken cancellationToken) => throw new NotImplementedException();
 	}
 
 	public class SyncTransformedCachedQueryWithoutProperties : SyncTransformedCachedQuery<object, object, object, object>
 	{
+		protected override void CacheKey(IKeyConfig keyConfig) => throw new NotImplementedException();
 		protected override object CacheEntryOptions(object context) => throw new NotImplementedException();
 		protected override object Query(object context) => throw new NotImplementedException();
 		protected override object TransformCachedResult(object cachedResult) => throw new NotImplementedException();
@@ -325,6 +328,7 @@ namespace Magneto.Tests.Core.OperationTests
 
 	public class AsyncTransformedCachedQueryWithoutProperties : AsyncTransformedCachedQuery<object, object, object, object>
 	{
+		protected override void CacheKey(IKeyConfig keyConfig) => throw new NotImplementedException();
 		protected override object CacheEntryOptions(object context) => throw new NotImplementedException();
 		protected override Task<object> Query(object context, CancellationToken cancellationToken) => throw new NotImplementedException();
 		protected override Task<object> TransformCachedResult(object cachedResult, CancellationToken cancellationToken) => throw new NotImplementedException();


### PR DESCRIPTION
So that implementers don't forget to set the `VaryBy` property.